### PR TITLE
Specified encoding parameter for module.xml

### DIFF
--- a/server_installation/topics/database/jdbc.adoc
+++ b/server_installation/topics/database/jdbc.adoc
@@ -13,7 +13,7 @@ After you have done this, open up the _module.xml_ file and create the following
 .Module XML
 [source,xml]
 ----
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.3" name="org.postgresql">
 
     <resources>


### PR DESCRIPTION
The lacking encoding parameter caused the JDBC module not to be found and 1 1/2 work days of headaches.